### PR TITLE
Add pygmentize.pl to modules

### DIFF
--- a/modules/source/pygmentize.pl
+++ b/modules/source/pygmentize.pl
@@ -1,0 +1,58 @@
+# Copyright (C) 2015  Alex-Daniel Jakimenko <alex.jakimenko@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+
+use strict;
+# use warnings;
+use v5.10;
+use utf8;
+
+package OddMuse;
+
+AddModuleDescription('pygmentize.pl', 'Pygmentize Extension');
+
+our ($q, $bol, %RuleOrder, @MyRules);
+
+# You can push other stuff to that list.
+# For example: push @PygmentizeArgs, qw(-F whitespace:spaces=true,tabs=true)
+# If you want to change existing options then just reinitialize the list
+our @PygmentizeArgs = qw(-O noclasses);
+
+push(@MyRules, \&PygmentizeRule);
+$RuleOrder{\&PygmentizeRule} = -60;
+
+sub PygmentizeRule {
+  if ($bol && m/\G\{\{\{(\w+)?[ \t]*\n(.*?)\n\}\}\}[ \t]*(\n|$)/cgs) {
+    my $lexer = $1;
+    my $contents = $2;
+    return CloseHtmlEnvironments() . DoPygmentize($contents, $lexer) . AddHtmlEnvironment('p');
+  }
+  return;
+}
+
+sub DoPygmentize {
+  my ($contents, $lexer) = @_;
+  $lexer = "-l \Q$lexer\E" if $lexer; # should be already safe, but \Q \E just because I'm paranoid
+  $lexer ||= '-g'; # -g for autodetect
+  my $args = join ' ', map { quotemeta } @PygmentizeArgs;
+  CreateDir($TempDir);
+  $contents = UnquoteHtml($contents);
+
+  RequestLockDir('pygmentize') or return '';
+  WriteStringToFile("$TempDir/pygmentize", $contents);
+  my $output = `pygmentize $lexer -f html -O encoding=utf8 $args -- \Q$TempDir/pygmentize\E`;
+  ReleaseLockDir('pygmentize');
+
+  utf8::decode($output);
+  return $output;
+}


### PR DESCRIPTION
I wanted to have syntax highlighting for so long. Dreams come true, please accept it!

* Module docs: http://oddmuse.org/wiki/Pygmentize_Extension
* Discussion here: http://oddmuse.org/wiki/Comments_on_Quick_Requests
* Somehow this is also part of http://oddmuse.org/wiki/Wiki_Refactoring. That's no wonder, the wiki is full of patches pasted right into the wiki. It would be so great if these were colored.

To make it work on old pages we have to clear the cache. Is it feasible?